### PR TITLE
Update `No_Position_Experiment.ipynb` for nbmake

### DIFF
--- a/demos/No_Position_Experiment.ipynb
+++ b/demos/No_Position_Experiment.ipynb
@@ -32,11 +32,12 @@
                 "DEBUG_MODE = False\n",
                 "DEVELOPMENT_MODE = False\n",
                 "DO_SLOW_RUNS = not IN_GITHUB\n",
+                "TORCH_DEVICE = \"cuda\" if not IN_GITHUB else \"cpu\"\n",
                 "EPOCHS_SIZE = 4000 if not IN_GITHUB else 25\n",
                 "\n",
                 "if IN_COLAB or IN_GITHUB:\n",
                 "    !pip install einops\n",
-                "    !pip install https://github.com/neelnanda-io/TransformerLens@no-position-experiment\n",
+                "    !pip install https://github.com/neelnanda-io/TransformerLens\n",
                 "\n",
                 "from transformer_lens import HookedTransformer, HookedTransformerConfig\n",
                 "import torch\n",
@@ -574,7 +575,7 @@
                 }
             ],
             "source": [
-                "cache[\"blocks.0.attn.hook_attn\"].shape"
+                "cache[\"blocks.0.attn.hook_attn_scores\"].shape"
             ]
         },
         {
@@ -730,7 +731,7 @@
                 "logit_components = (\n",
                 "    resid_stack[:, batch_index]\n",
                 "    @ fold_W_U\n",
-                "    / cache[\"scale\", None, \"ln_final\"][batch_index]\n",
+                "    / cache[\"ln_final.hook_scale\"][batch_index]\n",
                 ")\n",
                 "print(logit_components.shape)"
             ]
@@ -783,7 +784,7 @@
             "source": [
                 "logit_components = logit_components - logit_components.mean(-1, keepdim=True)\n",
                 "line(\n",
-                "    logit_components[:, torch.arange(1, model.cfg.n_ctx).cuda(), tokens[:-1]].T,\n",
+                "    logit_components[:, torch.arange(1, model.cfg.n_ctx).to(TORCH_DEVICE), tokens[:-1]].T,\n",
                 "    line_labels=labels,\n",
                 ")"
             ]
@@ -1212,7 +1213,7 @@
                 }
             ],
             "source": [
-                "new_token_batch = next(big_data_loader).cuda()\n",
+                "new_token_batch = next(big_data_loader).to(TORCH_DEVICE)\n",
                 "baseline_loss = loss_fn(model(new_token_batch), new_token_batch).item()\n",
                 "print(\"Baseline loss:\", baseline_loss)"
             ]
@@ -1271,6 +1272,9 @@
                 "losses = []\n",
                 "loss_labels = []\n",
                 "for hook_name in hook_list:\n",
+                "    if hook_name not in cache:\n",
+                "        continue\n",
+                "\n",
                 "    if hook_name != \"hook_pos_embed\" and \"result\" not in hook_name:\n",
                 "        average_act = cache[hook_name].mean(0)\n",
                 "\n",

--- a/demos/No_Position_Experiment.ipynb
+++ b/demos/No_Position_Experiment.ipynb
@@ -460,7 +460,7 @@
                 "losses = []\n",
                 "for epoch in tqdm.tqdm(range(num_epochs)):\n",
                 "    tokens = next(data_loader)\n",
-                "    tokens = tokens.cuda() if not IN_GITHUB else tokens\n",
+                "    tokens = tokens.to(TORCH_DEVICE)\n",
                 "    logits = model(tokens)\n",
                 "    loss = loss_fn(logits, tokens)\n",
                 "    loss.backward()\n",
@@ -534,8 +534,7 @@
             "source": [
                 "big_data_loader = make_data_generator(cfg, EPOCHS_SIZE)\n",
                 "big_tokens = next(big_data_loader)\n",
-                "if not IN_GITHUB:\n",
-                "     big_tokens = big_tokens.cuda()\n",
+                "big_tokens = big_tokens.to(TORCH_DEVICE)\n",
                 "\n",
                 "logits, cache = model.run_with_cache(big_tokens)\n",
                 "print(\"Loss:\", loss_fn(logits, big_tokens).item())"


### PR DESCRIPTION
# Changes
Update cache keys to get nbmake test to pass.

# Notes
- It seems like the tag `@no-position-experiment` has been deleted. I think this means that some of the keys in the activation cache have changed name, for example `cache["blocks.0.attn.hook_attn"]` had to be replaced with `cache["blocks.0.attn.hook_attn_scores"]`.
- I think it might actually be better to reinstate the tag, so that the notebook is consistent with the youtube tutorial